### PR TITLE
feat: Enterprise architecture hardening and stability updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder Stage
-FROM golang:1.26-alpine@sha256:f44b851aa23dfa219d18db6eab743203245429d355cb619cf96a2ffe2a84ba7a AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o loopers ./cmd/loopers
 
 # Final Stage
-FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+FROM alpine:3.21
 
 RUN apk --no-cache add ca-certificates && \
     addgroup -S loopers && adduser -S loopers -G loopers

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="left">
   <img src="https://img.shields.io/badge/license-MIT-black.svg?style=for-the-badge" alt="License" />
-  <img src="https://img.shields.io/badge/go-1.26.3-black.svg?style=for-the-badge" alt="Go Version" />
+  <img src="https://img.shields.io/badge/go-1.26.4-black.svg?style=for-the-badge" alt="Go Version" />
   <img src="https://img.shields.io/badge/models-500%2B%20Supported-black.svg?style=for-the-badge" alt="Models Supported" />
   <a href="https://github.com/CURSED-ME/loopers-oss/actions/workflows/ci.yml"><img src="https://github.com/CURSED-ME/loopers-oss/actions/workflows/ci.yml/badge.svg" alt="Build Status" /></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CURSED-ME/loopers-oss"><img src="https://api.securityscorecards.dev/projects/github.com/CURSED-ME/loopers-oss/badge?style=for-the-badge" alt="OpenSSF Scorecard" /></a>
@@ -21,6 +21,12 @@ Loopers is a baremetal, zero-delay circuit breaker for AI API billing. It interc
 ---
 
 ## What's New
+
+**Enterprise-Grade Security Architecture**
+We have significantly hardened Loopers for bare-metal and zero-trust deployments:
+- **Dedicated Admin Server:** Telemetry (`/metrics`) and health checks are now isolated on a dedicated admin port (default `9090`), preventing internal state exposure when the main proxy (`8080`) is public.
+- **Strict TLS Enforcement:** Production deployments now mandate TLS certificates to start, preventing accidental plaintext exposure.
+- **Hardened Redis Integrations:** Redis connections now require password authentication natively out of the box in our Helm charts and Compose templates.
 
 **Bring Your Own Provider (Generic OpenAI-Compatible Endpoints)**
 You are no longer limited to the built-in providers! Loopers now supports routing to *any* OpenAI-compatible endpoint (like vLLM, OpenRouter, local Llama.cpp, or custom proxies) while still maintaining full budget enforcement, mid-stream cutoffs, and loop detection. Configure them easily via `generic_providers` in `loopers.yaml`.
@@ -262,7 +268,7 @@ For a detailed system overview and sequence diagram, please see our [Architectur
 
 ## Monitoring
 
-Loopers exposes a Prometheus metrics endpoint out of the box. A pre-built Grafana dashboard is included in [`./grafana/`](./grafana/) for instant observability into request throughput, budget block rates, and latency percentiles.
+Loopers exposes a Prometheus metrics endpoint out of the box on a dedicated, isolated admin port (default: `9090`). A pre-built Grafana dashboard is included in [`./grafana/`](./grafana/) for instant observability into request throughput, budget block rates, and latency percentiles.
 
 ---
 

--- a/cmd/loopers/commands.go
+++ b/cmd/loopers/commands.go
@@ -130,8 +130,9 @@ var serveCmd = &cobra.Command{
 
 		certFile := viper.GetString("server.tls_cert_file")
 		keyFile := viper.GetString("server.tls_key_file")
+		insecureDev := viper.GetBool("server.insecure_dev")
 
-		server.ListenAndServeWithGracefulShutdown(srv, adminSrv, redisClient, certFile, keyFile)
+		server.ListenAndServeWithGracefulShutdown(srv, adminSrv, redisClient, certFile, keyFile, insecureDev)
 	},
 }
 

--- a/cmd/loopers/commands.go
+++ b/cmd/loopers/commands.go
@@ -113,12 +113,25 @@ var serveCmd = &cobra.Command{
 			port = "8080"
 		}
 
+		adminPort := viper.GetString("server.admin_port")
+		if adminPort == "" {
+			adminPort = "9090"
+		}
+
 		srv := &http.Server{
 			Addr:    ":" + port,
 			Handler: s.GetRouter(),
 		}
 
-		server.ListenAndServeWithGracefulShutdown(srv, redisClient)
+		adminSrv := &http.Server{
+			Addr:    ":" + adminPort,
+			Handler: s.GetAdminRouter(),
+		}
+
+		certFile := viper.GetString("server.tls_cert_file")
+		keyFile := viper.GetString("server.tls_key_file")
+
+		server.ListenAndServeWithGracefulShutdown(srv, adminSrv, redisClient, certFile, keyFile)
 	},
 }
 
@@ -615,6 +628,9 @@ var initCmd = &cobra.Command{
 		// Generate loopers.yaml
 		yamlContent := fmt.Sprintf(`server:
   port: 8080
+  # admin_port: 9090
+  # tls_cert_file: "/path/to/cert.pem"
+  # tls_key_file: "/path/to/key.pem"
 redis:
   addr: "%s"
   password: ""
@@ -634,7 +650,7 @@ alerting:
       message: "Budget 95%% consumed — imminent cutoff"
 `, redisInput)
 
-		err := os.WriteFile("loopers.yaml", []byte(yamlContent), 0644)
+		err := os.WriteFile("loopers.yaml", []byte(yamlContent), 0600)
 		if err != nil {
 			ui.Error(fmt.Sprintf("Error writing loopers.yaml: %v", err))
 			return
@@ -646,12 +662,13 @@ alerting:
 
 services:
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
     container_name: loopers-redis
-    ports:
-      - "6379:6379"
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD:-demo-pass}"]
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-demo-pass}
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "sh", "-c", "redis-cli -a $$REDIS_PASSWORD ping"]
       interval: 2s
       timeout: 2s
       retries: 5
@@ -665,6 +682,7 @@ services:
       - "8080:8080"
     environment:
       - REDIS_ADDR=redis:6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-demo-pass}
       - SERVER_PORT=8080
       - PRICING_PATH=/app/pricing.yaml
     depends_on:
@@ -677,7 +695,7 @@ networks:
   loopers-net:
     driver: bridge
 `
-		err = os.WriteFile("docker-compose.yml", []byte(composeContent), 0644)
+		err = os.WriteFile("docker-compose.yml", []byte(composeContent), 0600)
 		if err != nil {
 			ui.Error(fmt.Sprintf("Error writing docker-compose.yml: %v", err))
 			return

--- a/cmd/loopers/main.go
+++ b/cmd/loopers/main.go
@@ -83,6 +83,7 @@ func initConfig() {
 	viper.BindEnv("redis.addr", "REDIS_ADDR")
 	viper.BindEnv("redis.password", "REDIS_PASSWORD")
 	viper.BindEnv("server.port", "SERVER_PORT")
+	viper.BindEnv("server.insecure_dev", "SERVER_INSECURE_DEV")
 	viper.BindEnv("pricing_path", "PRICING_PATH")
 	viper.BindEnv("log.level", "LOG_LEVEL")
 

--- a/cmd/loopers/main.go
+++ b/cmd/loopers/main.go
@@ -81,6 +81,7 @@ func initConfig() {
 	viper.AutomaticEnv()
 
 	viper.BindEnv("redis.addr", "REDIS_ADDR")
+	viper.BindEnv("redis.password", "REDIS_PASSWORD")
 	viper.BindEnv("server.port", "SERVER_PORT")
 	viper.BindEnv("pricing_path", "PRICING_PATH")
 	viper.BindEnv("log.level", "LOG_LEVEL")

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -2,10 +2,13 @@ version: '3.8'
 
 services:
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
+    command: ["redis-server", "--requirepass", "demo-pass"]
+    environment:
+      - REDIS_PASSWORD=demo-pass
     networks: [loopers-demo]
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "sh", "-c", "redis-cli -a $$REDIS_PASSWORD ping"]
       interval: 2s
       timeout: 2s
       retries: 5
@@ -23,6 +26,7 @@ services:
       - "8080:8080"
     environment:
       - REDIS_ADDR=redis:6379
+      - REDIS_PASSWORD=demo-pass
       - SERVER_PORT=8080
       - LOG_LEVEL=info
       - PRICING_PATH=/app/pricing.yaml
@@ -36,6 +40,7 @@ services:
     image: ghcr.io/cursed-me/loopers:latest
     environment:
       - REDIS_ADDR=redis:6379
+      - REDIS_PASSWORD=demo-pass
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   redis:
@@ -28,6 +27,7 @@ services:
       - REDIS_ADDR=redis:6379
       - REDIS_PASSWORD=demo-pass
       - SERVER_PORT=8080
+      - SERVER_INSECURE_DEV=true
       - LOG_LEVEL=info
       - PRICING_PATH=/app/pricing.yaml
       - OPENAI_BASE_URL=http://mock-openai

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,13 @@ version: '3.8'
 
 services:
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
     container_name: loopers-redis
-    ports:
-      - "6379:6379"
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "sh", "-c", "redis-cli -a $$REDIS_PASSWORD ping"]
       interval: 2s
       timeout: 2s
       retries: 5
@@ -21,6 +22,7 @@ services:
       - "8080:8080"
     environment:
       - REDIS_ADDR=redis:6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
       - SERVER_PORT=8080
       - PRICING_PATH=/app/pricing.yaml
     depends_on:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/loopers-oss/loopers
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/helm/loopers/templates/deployment.yaml
+++ b/helm/loopers/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: admin
+              containerPort: 9090
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /health

--- a/helm/loopers/templates/service.yaml
+++ b/helm/loopers/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.adminPort }}
+      targetPort: admin
+      protocol: TCP
+      name: admin
   selector:
     {{- include "loopers.selectorLabels" . | nindent 4 }}

--- a/helm/loopers/templates/servicemonitor.yaml
+++ b/helm/loopers/templates/servicemonitor.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       {{- include "loopers.selectorLabels" . | nindent 6 }}
   endpoints:
-    - port: http
+    - port: admin
       path: {{ .Values.serviceMonitor.path | default "/metrics" }}
       interval: {{ .Values.serviceMonitor.interval | default "30s" }}
 {{- end }}

--- a/helm/loopers/values.yaml
+++ b/helm/loopers/values.yaml
@@ -8,6 +8,7 @@ image:
 service:
   type: ClusterIP
   port: 8080
+  adminPort: 9090
 
 resources:
   limits:
@@ -31,7 +32,7 @@ serviceMonitor:
 redis:
   enabled: true
   auth:
-    enabled: false
+    enabled: true
   architecture: standalone
   master:
     resources:

--- a/internal/budget/engine.go
+++ b/internal/budget/engine.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
-var configCache = cache.NewTTLCache(30 * time.Second)
+var configCache = cache.NewTTLCache(10 * time.Second)
 var configGroup singleflight.Group
 
 // BudgetExceededError is returned when a budget limit is reached.

--- a/internal/budget/lease.go
+++ b/internal/budget/lease.go
@@ -144,8 +144,6 @@ func (lm *LeaseManager) ReconcileSpend(keyHash string, estCostUSD float64, actua
 	lease.SpentNano.Add(-deltaNano)
 }
 
-
-
 // ErrBudgetExceeded is returned when the global budget is too low.
 var ErrBudgetExceeded = errors.New("budget exceeded")
 

--- a/internal/budget/lease.go
+++ b/internal/budget/lease.go
@@ -2,6 +2,7 @@ package budget
 
 import (
 	"context"
+	"errors"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -143,8 +144,10 @@ func (lm *LeaseManager) ReconcileSpend(keyHash string, estCostUSD float64, actua
 	lease.SpentNano.Add(-deltaNano)
 }
 
+
+
 // ErrBudgetExceeded is returned when the global budget is too low.
-var ErrBudgetExceeded = context.DeadlineExceeded // Just reusing a common error interface for now, will refine
+var ErrBudgetExceeded = errors.New("budget exceeded")
 
 // TryAcquireFast attempts to deduct from the local lease instantly without calling Redis.
 // Returns false if the local lease is exhausted.

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -16,10 +16,26 @@ type TTLCache struct {
 	ttl time.Duration
 }
 
-// NewTTLCache creates a new TTLCache with the specified TTL.
+// NewTTLCache creates a new TTLCache with the specified TTL and starts a background sweep.
 func NewTTLCache(ttl time.Duration) *TTLCache {
-	return &TTLCache{
+	c := &TTLCache{
 		ttl: ttl,
+	}
+	go c.startSweep()
+	return c
+}
+
+func (c *TTLCache) startSweep() {
+	ticker := time.NewTicker(time.Minute)
+	for range ticker.C {
+		now := time.Now()
+		c.m.Range(func(key, value interface{}) bool {
+			entry := value.(cacheEntry)
+			if now.After(entry.expiresAt) {
+				c.m.Delete(key)
+			}
+			return true
+		})
 	}
 }
 

--- a/internal/keyring/extractor.go
+++ b/internal/keyring/extractor.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
-var keyMetaCache = cache.NewTTLCache(30 * time.Second)
+var keyMetaCache = cache.NewTTLCache(10 * time.Second)
 var keyMetaGroup singleflight.Group
 
 // KeyMetadata represents the fields stored in Redis for a loopers API key.

--- a/internal/pricing/remote.go
+++ b/internal/pricing/remote.go
@@ -5,13 +5,26 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
 // FetchRemotePricing fetches the remote pricing JSON and returns a Config.
-func FetchRemotePricing(url string) (*Config, error) {
+func FetchRemotePricing(urlStr string) (*Config, error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		host := strings.Split(u.Host, ":")[0]
+		if host != "localhost" && host != "127.0.0.1" {
+			return nil, fmt.Errorf("remote pricing URL must be HTTPS or localhost")
+		}
+	}
+
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(url)
+	resp, err := client.Get(urlStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch remote pricing: %w", err)
 	}

--- a/internal/server/graceful.go
+++ b/internal/server/graceful.go
@@ -13,16 +13,29 @@ import (
 )
 
 // ListenAndServeWithGracefulShutdown starts the HTTP server and listens for SIGTERM/SIGINT.
-func ListenAndServeWithGracefulShutdown(srv *http.Server, redisClient interface{ Close() error }) {
+func ListenAndServeWithGracefulShutdown(srv *http.Server, adminSrv *http.Server, redisClient interface{ Close() error }, certFile, keyFile string) {
 	// Channel to listen for signals
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logging.Logger.Fatal().Err(err).Msg("Server failed to start")
+		if certFile != "" && keyFile != "" {
+			if err := srv.ListenAndServeTLS(certFile, keyFile); err != nil && err != http.ErrServerClosed {
+				logging.Logger.Fatal().Err(err).Msg("Server failed to start (TLS)")
+			}
+		} else {
+			logging.Logger.Fatal().Msg("TLS is required in production. Please configure server.tls_cert_file and server.tls_key_file")
 		}
 	}()
+
+	if adminSrv != nil {
+		go func() {
+			logging.Logger.Info().Msgf("Admin server started listening on %s", adminSrv.Addr)
+			if err := adminSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				logging.Logger.Fatal().Err(err).Msg("Admin server failed to start")
+			}
+		}()
+	}
 
 	logging.Logger.Info().Msgf("Server started listening on %s", srv.Addr)
 
@@ -41,6 +54,14 @@ func ListenAndServeWithGracefulShutdown(srv *http.Server, redisClient interface{
 		logging.Logger.Error().Err(err).Msg("Server forced to shutdown prematurely")
 	} else {
 		logging.Logger.Info().Msg("HTTP server closed gracefully")
+	}
+
+	if adminSrv != nil {
+		if err := adminSrv.Shutdown(ctx); err != nil {
+			logging.Logger.Error().Err(err).Msg("Admin server forced to shutdown prematurely")
+		} else {
+			logging.Logger.Info().Msg("Admin server closed gracefully")
+		}
 	}
 
 	// Close Redis connection pool

--- a/internal/server/graceful.go
+++ b/internal/server/graceful.go
@@ -13,12 +13,20 @@ import (
 )
 
 // ListenAndServeWithGracefulShutdown starts the HTTP server and listens for SIGTERM/SIGINT.
-func ListenAndServeWithGracefulShutdown(srv *http.Server, adminSrv *http.Server, redisClient interface{ Close() error }, certFile, keyFile string) {
+func ListenAndServeWithGracefulShutdown(srv *http.Server, adminSrv *http.Server, redisClient interface{ Close() error }, certFile, keyFile string, insecureDev bool) {
 	// Channel to listen for signals
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
+		if insecureDev {
+			logging.Logger.Warn().Msg("SERVER_INSECURE_DEV is true. Starting proxy in plaintext mode without TLS. DO NOT USE IN PRODUCTION.")
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				logging.Logger.Fatal().Err(err).Msg("Server failed to start")
+			}
+			return
+		}
+
 		if certFile != "" && keyFile != "" {
 			if err := srv.ListenAndServeTLS(certFile, keyFile); err != nil && err != http.ErrServerClosed {
 				logging.Logger.Fatal().Err(err).Msg("Server failed to start (TLS)")

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -28,6 +28,14 @@ func RequestID() gin.HandlerFunc {
 		reqID := c.GetHeader("X-Request-ID")
 		if reqID == "" {
 			reqID = uuid.New().String()
+		} else {
+			// Sanitize to prevent log injection
+			reqID = strings.Map(func(r rune) rune {
+				if r < 32 || r >= 127 {
+					return -1
+				}
+				return r
+			}, reqID)
 		}
 		c.Set(RequestIDKey, reqID)
 		c.Header("X-Request-ID", reqID)
@@ -138,9 +146,19 @@ var bufferPool = sync.Pool{
 func ConcurrencyLimiter(maxInflight int) gin.HandlerFunc {
 	sema := make(chan struct{}, maxInflight)
 	return func(c *gin.Context) {
-		sema <- struct{}{}        // Acquire slot
-		defer func() { <-sema }() // Release slot when request finishes (after c.Next() completes)
-		c.Next()
+		select {
+		case sema <- struct{}{}:
+			defer func() { <-sema }()
+			c.Next()
+		case <-time.After(5 * time.Second):
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{
+				"error": gin.H{
+					"message": "Service overloaded, too many concurrent requests",
+					"type":    "rate_limit_error",
+					"code":    "service_unavailable",
+				},
+			})
+		}
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -82,6 +82,8 @@ var (
 		Name: "loopers_tokens_total",
 		Help: "Total number of tokens processed by Loopers",
 	}, []string{"provider", "direction"})
+
+	validSessionID = regexp.MustCompile(`^[a-zA-Z0-9._:@/-]{1,256}$`)
 )
 
 type serverContextKey string
@@ -202,7 +204,6 @@ func (s *Server) setupRoutes() {
 	s.router.Use(KeyExtractor())
 
 	s.router.GET("/health", s.handleHealth)
-	s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 	s.router.GET("/budget/status", s.handleBudgetStatus)
 
 	s.proxyGroup = s.router.Group("/")
@@ -451,6 +452,13 @@ func (s *Server) handleProxy(c *gin.Context, providerName string) {
 sessionCheck:
 	// 6.5 Session budget and step limits check (if X-Loopers-Session-ID is present)
 	sessionID := c.GetHeader("X-Loopers-Session-ID")
+	if sessionID != "" {
+		if !validSessionID.MatchString(sessionID) {
+			requestsTotal.WithLabelValues(providerName, model, "400").Inc()
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Invalid session ID format"})
+			return
+		}
+	}
 	var sessionBudget float64
 	var sessionMaxSteps int
 	if sessionID != "" {
@@ -765,6 +773,15 @@ func (s *Server) modifyResponse(resp *http.Response) error {
 // GetRouter retrieves the Gin engine.
 func (s *Server) GetRouter() *gin.Engine {
 	return s.router
+}
+
+// GetAdminRouter retrieves the Gin engine for the admin port.
+func (s *Server) GetAdminRouter() *gin.Engine {
+	adminRouter := gin.New()
+	adminRouter.Use(gin.Recovery())
+	adminRouter.GET("/health", s.handleHealth)
+	adminRouter.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	return adminRouter
 }
 
 // GetRegistry retrieves the provider registry. Primarily used for testing.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -155,5 +156,70 @@ func TestBudgetStatusEndpoint(t *testing.T) {
 
 	if statusMap["daily"].Limit != 20.0 {
 		t.Errorf("Expected daily limit 20.0, got %f", statusMap["daily"].Limit)
+	}
+}
+
+func TestSessionIDValidation(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	redisClient, err := budget.NewClient(mr.Addr(), "", 0)
+	if err != nil {
+		t.Fatalf("Failed to create redis client: %v", err)
+	}
+	defer redisClient.Close()
+
+	// Load pricing
+	pricingStore, _ := pricing.LoadStore("../../pricing.yaml")
+	s := NewServer(redisClient, pricingStore)
+	
+	// Register mock provider
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"result":"ok"}`))
+	}))
+	defer upstream.Close()
+	s.RegisterProviderRoute(&mockProvider{baseURL: upstream.URL})
+
+	rawKey, _ := keyring.GenerateRawKey()
+	keyHash := keyring.HashKey(rawKey)
+	ctx := context.Background()
+	rdb := redisClient.GetUnderlyingClient()
+	rdb.HSet(ctx, "loopers:key:"+keyHash, map[string]interface{}{
+		"name":     "test-key",
+		"provider": "mock",
+		"active":   "true",
+	})
+	defer rdb.Del(ctx, "loopers:key:"+keyHash)
+
+	tests := []struct {
+		name      string
+		sessionID string
+		wantCode  int
+	}{
+		{"valid standard", "sess-123", http.StatusOK},
+		{"valid email-like", "user@domain.com", http.StatusOK},
+		{"valid url-like", "org/team/session", http.StatusOK},
+		{"valid complex", "org:team:session_123.45-67@domain/path", http.StatusOK},
+		{"invalid space", "sess 123", http.StatusBadRequest},
+		{"invalid special char", "sess!123", http.StatusBadRequest},
+		{"invalid quotes", "sess\"123\"", http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("POST", "/mock/v1/chat", bytes.NewBuffer([]byte(`{"model":"mock-model"}`)))
+			req.Header.Set("Authorization", "Bearer "+rawKey)
+			req.Header.Set("X-Loopers-Provider-Key", "dummy")
+			req.Header.Set("X-Loopers-Session-ID", tt.sessionID)
+			w := newCloseNotifierRecorder()
+			s.GetRouter().ServeHTTP(w, req)
+			if w.Code != tt.wantCode {
+				t.Errorf("Expected status %d, got %d. Body: %s", tt.wantCode, w.Code, w.Body.String())
+			}
+		})
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -175,7 +175,7 @@ func TestSessionIDValidation(t *testing.T) {
 	// Load pricing
 	pricingStore, _ := pricing.LoadStore("../../pricing.yaml")
 	s := NewServer(redisClient, pricingStore)
-	
+
 	// Register mock provider
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
- Isolate metrics to dedicated admin server on port 9090
- Mandate TLS certificates in production proxy startup
- Enforce Redis password authentication in deployments
- Validate Session-ID HTTP headers
- Refactor cache TTLs and update Go version to 1.26.4
- Enhance system robustness against request bursts